### PR TITLE
New functionality to share with Facebook and Twitter selectively

### DIFF
--- a/Social.h
+++ b/Social.h
@@ -4,6 +4,7 @@
 //  Cameron Lerch
 //  Sponsored by Brightflock: http://brightflock.com
 //
+// Enhanced by Victor Tsaran: http://www.victortsaran.net
 
 #import <Cordova/CDVPlugin.h>
 #import <Cordova/CDVPluginResult.h>
@@ -14,5 +15,7 @@
 - (void)available:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
 
 - (void)share:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+
+- (void)shareA:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
 
 @end

--- a/Social.m
+++ b/Social.m
@@ -4,7 +4,10 @@
 //  Cameron Lerch
 //  Sponsored by Brightflock: http://brightflock.com
 //
+// Enhanced by Victor Tsaran: http://www.victortsaran.net
 
+#import <Social/SLComposeViewController.h>
+#import <Social/SLServiceTypes.h>
 #import "Social.h"
 
 @interface Social ()
@@ -54,7 +57,50 @@
     UIActivityViewController *activityVC =
     [[UIActivityViewController alloc] initWithActivityItems:activityItems
                                       applicationActivities:applicationActivities];
+		activityVC.excludedActivityTypes = @[UIActivityTypePostToWeibo, UIActivityTypeAssignToContact, UIActivityTypePrint, UIActivityTypeCopyToPasteboard, UIActivityTypeSaveToCameraRoll];
+
     [self.viewController presentViewController:activityVC animated:YES completion:nil];
+}
+
+- (void)shareA:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options {
+		if (!NSClassFromString(@"SLComposeViewController")) {
+				return;
+		}
+
+		NSString *serviceType = [arguments objectAtIndex:1];
+		NSString *text = [arguments objectAtIndex:2];
+
+		NSString *imageName = [arguments objectAtIndex:3];
+		UIImage *image = nil;
+
+		if (imageName) {
+				image = [UIImage imageNamed:imageName];
+		}
+
+		NSString *urlString = [arguments objectAtIndex:4];
+		NSURL *url = nil;
+
+		if (urlString) {
+				url = [NSURL URLWithString:urlString];
+		}
+
+		if ([serviceType isEqual: @"Twitter"])
+				serviceType = SLServiceTypeTwitter;
+else if ([serviceType isEqual: @"Facebook"])
+		serviceType = SLServiceTypeFacebook;
+else if ([serviceType isEqual: @"SinaWeibo"])
+		serviceType = SLServiceTypeSinaWeibo;
+		else
+				return;
+
+		if([SLComposeViewController isAvailableForServiceType:serviceType]) {
+				SLComposeViewController*serviceViewController = [SLComposeViewController
+																																			composeViewControllerForServiceType:serviceType];
+				[serviceViewController setInitialText:text];
+				[serviceViewController addImage:image];
+				[serviceViewController addURL:url];
+				[self.viewController presentViewController:serviceViewController animated:YES completion:nil];
+		}
 }
 
 @end

--- a/Social.m
+++ b/Social.m
@@ -93,14 +93,16 @@ else if ([serviceType isEqual: @"SinaWeibo"])
 		else
 				return;
 
-		if([SLComposeViewController isAvailableForServiceType:serviceType]) {
+// Uncomment the following conditional if you want to perform your own action in case serviceType account is not present.
+// Otherwise, we will let the OS display its own dialog.
+//		if([SLComposeViewController isAvailableForServiceType:serviceType]) {
 				SLComposeViewController*serviceViewController = [SLComposeViewController
 																																			composeViewControllerForServiceType:serviceType];
 				[serviceViewController setInitialText:text];
 				[serviceViewController addImage:image];
 				[serviceViewController addURL:url];
 				[self.viewController presentViewController:serviceViewController animated:YES completion:nil];
-		}
+		//		}
 }
 
 @end

--- a/social.js
+++ b/social.js
@@ -15,9 +15,13 @@ Social.prototype.available = function(callback) {
 };
 
 Social.prototype.share = function(message, url, image) {
-    cordova.exec(null, null, "Social", "share", [message, image, url]);
+		cordova.exec(null, null, "Social", "share", [message, image, url]);
 };
-    
+
+Social.prototype.shareA = function(service, message, url, image) {
+		cordova.exec(null, null, "Social", "shareA", [service, message, image, url]);
+};
+
 Social.install = function() {
     if (!window.plugins) {
         window.plugins = {};	


### PR DESCRIPTION
Introduced the new method called "shareA" that allows sharing with Facebook or Twitter selectively (using SLComposeViewController). "shareA" takes four parameters:
1.  Service Name (Facebook, Twitter or Sinaweibo). -- string
2.  Text to tweet -- string.
3.  URL to post -- string.
4.  Path to the image to attach -- string.

A call would look something like this:

<code>
window.plugin.social.shareA('Facebook', 'I love guitar!', 'http://www.victortsaran.net', 'my image.gif');
</code>

I am willing to see this merged into the main "share" method but I didn't want to do anything major until I hear back from the original author.

Looking forward to your feedback.
Victor
